### PR TITLE
Fix minor dev setup typo

### DIFF
--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -19,7 +19,7 @@ install the operator-sdk tools.
     kubectl create namespace metal3
     ```
 
-4. Install operator-sdk
+4. Install the operator
 
     ```
     eval $(go env)


### PR DESCRIPTION
The quoted instructions is about installing the operator, and the operator-sdk
is installed earlier.